### PR TITLE
Fix too high ressource usage caused by wrong share

### DIFF
--- a/deflex/basic_scenario.py
+++ b/deflex/basic_scenario.py
@@ -569,12 +569,12 @@ def chp_table(heat_b, heat_demand, table_collection, regions=None):
 
             # CHP
             trsf.loc["limit_heat_chp", (region, src)] = round(
-                sum_val * share.loc[rows[0], fuel] *
-                out_share_factor_chp + 0.5
+                sum_val * share.loc[rows[0], fuel] * out_share_factor_chp + 0.5
             )
             cap_heat_chp = round(
                 max_val * share.loc[rows[0], fuel] * out_share_factor_chp
-                + 0.005, 2
+                + 0.005,
+                2,
             )
             trsf.loc["capacity_heat_chp", (region, src)] = cap_heat_chp
             cap_elec = cap_heat_chp / eta_heat_chp * eta_elec_chp
@@ -596,12 +596,12 @@ def chp_table(heat_b, heat_demand, table_collection, regions=None):
 
             # HP
             trsf.loc["limit_hp", (region, src)] = round(
-                sum_val * share.loc[rows[1], fuel] *
-                out_share_factor_hp + 0.5
+                sum_val * share.loc[rows[1], fuel] * out_share_factor_hp + 0.5
             )
             trsf.loc["capacity_hp", (region, src)] = round(
                 max_val * share.loc[rows[1], fuel] * out_share_factor_hp
-                + 0.005, 2
+                + 0.005,
+                2,
             )
             if trsf.loc["capacity_hp", (region, src)] > 0:
                 trsf.loc["efficiency_hp", (region, src)] = eta_hp

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "oemof >= 0.3.0",
         "pandas >= 0.17.0",
-        "reegis >= v0.1.0",
+        "reegis > v0.1.1",
         "demandlib",
         "workalendar",
         "networkx",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,22 +38,23 @@ class TestMain:
     def test_main_secure_with_es(self):
         main.main(2014, "de21", es=self.es, extra_regions=["DE03", "DE07"])
         fn = os.path.join(
-                self.base_path,
-                "deflex",
-                "2014",
-                "results_cbc",
-                "deflex_2014_de21.esys",
-            )
+            self.base_path,
+            "deflex",
+            "2014",
+            "results_cbc",
+            "deflex_2014_de21.esys",
+        )
         assert os.path.isfile(fn)
         sc = scenario_tools.Scenario()
         sc.restore_es(fn)
         flows = [x for x in sc.es.results["main"].keys() if x[1] is not None]
         commodity_regions = [
-            x[0].label.region for x in flows
-            if x[1].label.tag == "commodity" and
-            x[1].label.subtag == "natural_gas" and
-            x[1].label.cat == "bus" and
-            x[0].label.cat == "source"
+            x[0].label.region
+            for x in flows
+            if x[1].label.tag == "commodity"
+            and x[1].label.subtag == "natural_gas"
+            and x[1].label.cat == "bus"
+            and x[0].label.cat == "source"
         ]
         eq_(commodity_regions, ["DE", "DE03", "DE07"])
 

--- a/tests/test_scenario_powerplant_and_chp.py
+++ b/tests/test_scenario_powerplant_and_chp.py
@@ -75,5 +75,5 @@ class TestScenarioPowerplantsAndCHP:
         transf = basic_scenario.scenario_chp(
             self.pp, self.regions, 2014, "de21"
         )["transformer"]
-        eq_(int(transf.loc["capacity", ("DE01", "hard coal")]), 485)
-        eq_(int(transf.loc["capacity_elec_chp", ("DE01", "hard coal")]), 806)
+        eq_(int(transf.loc["capacity", ("DE01", "hard coal")]), 623)
+        eq_(int(transf.loc["capacity_elec_chp", ("DE01", "hard coal")]), 667)


### PR DESCRIPTION
The fuel share was used instead of the output share. Both values differ because of a differnet efficiency.
